### PR TITLE
Added timeouts to wait for transmission loops

### DIFF
--- a/i2c.h
+++ b/i2c.h
@@ -17,7 +17,7 @@
  */
 
 #define MAX_ITER 200  //< maximum retries
-#define MAX_TIMEOUT 5000  //< maximum timeout while waiting for I2C response
+#define MAX_TIMEOUT 250  //< maximum timeout while waiting for I2C response
 uint8_t twst;
 
 //uint8_t StartTwiTransfer(uint8_t dr)
@@ -61,8 +61,12 @@ begin:
 
     m=0;
     TWCR = _BV(TWINT) | _BV(TWSTA) | _BV(TWEN); /* send start condition */
-    while (((TWCR & _BV(TWINT)) == 0) && (++m < MAX_TIMEOUT)) ; /* wait for transmission */
-    if (m == MAX_TIMEOUT) return 0xFF;
+    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_TIMEOUT)) ; /* wait for transmission */
+	if (m > MAX_TIMEOUT) {
+		putch('1');
+		return 0xFF; 
+	}
+	
 	switch ((twst = TW_STATUS)) {
         case TW_REP_START:		// OK, but should not happen 
         case TW_START:
@@ -79,8 +83,12 @@ begin:
     m = 0;
     TWDR = I2C_EEPROM_ADDR | TW_WRITE;
     TWCR = _BV(TWINT) | _BV(TWEN); /* clear interrupt to start transmission */
-    while (((TWCR & _BV(TWINT)) == 0) && (++m < MAX_TIMEOUT)) ; /* wait for transmission */
-    if (m == MAX_TIMEOUT) goto error;
+    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_TIMEOUT)) ; /* wait for transmission */
+    if (m > MAX_TIMEOUT) {
+		putch('2');
+		goto error;
+	}
+	
 	switch ((twst = TW_STATUS)) {
         case TW_MT_SLA_ACK:
             break;
@@ -99,9 +107,12 @@ begin:
     m = 0;
     TWDR = ((uint16_t)eeaddr >> 8);		/* 16-bit word address device, send high 8 bits of addr */
     TWCR = _BV(TWINT) | _BV(TWEN); /* clear interrupt to start transmission */
-    while (((TWCR & _BV(TWINT)) == 0) && (++m < MAX_TIMEOUT)); /* wait for transmission */
-	if (m == MAX_TIMEOUT) goto error;
-    switch ((twst = TW_STATUS)) {
+    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_TIMEOUT)); /* wait for transmission */
+	if (m > MAX_TIMEOUT) {
+		putch('3');
+		goto error;
+	}
+	switch ((twst = TW_STATUS)) {
         case TW_MT_DATA_ACK:
             break;
         case TW_MT_DATA_NACK:
@@ -115,9 +126,12 @@ begin:
     m = 0;
     TWDR = eeaddr;		/* low 8 bits of addr */
     TWCR = _BV(TWINT) | _BV(TWEN); /* clear interrupt to start transmission */
-    while (((TWCR & _BV(TWINT)) == 0) && (++m < MAX_TIMEOUT)) ; /* wait for transmission */
-	if (m == MAX_TIMEOUT) goto error;
-    switch ((twst = TW_STATUS)) {
+    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_TIMEOUT)) ; /* wait for transmission */
+	if (m > MAX_TIMEOUT){
+		putch('4');
+		goto error;
+	}
+	switch ((twst = TW_STATUS)) {
         case TW_MT_DATA_ACK:
             break;
         case TW_MT_DATA_NACK:
@@ -134,9 +148,12 @@ begin:
     */
     m = 0;
     TWCR = _BV(TWINT) | _BV(TWSTA) | _BV(TWEN); /* send (rep.) start condition */
-    while (((TWCR & _BV(TWINT)) == 0) && (++m < MAX_TIMEOUT)) ; /* wait for transmission */
-	if (m == MAX_TIMEOUT) goto error;
-    switch ((twst = TW_STATUS)) {
+    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_TIMEOUT)) ; /* wait for transmission */
+	if (m > MAX_TIMEOUT) {
+		putch('5');
+		goto error;
+	}
+	switch ((twst = TW_STATUS)) {
         case TW_START:		// OK, but should not happen 
         case TW_REP_START:
             break;
@@ -150,9 +167,12 @@ begin:
     m = 0;
     TWDR = I2C_EEPROM_ADDR | TW_READ;
     TWCR = _BV(TWINT) | _BV(TWEN); /* clear interrupt to start transmission */
-    while (((TWCR & _BV(TWINT)) == 0) && (++m < MAX_TIMEOUT)); /* wait for transmission */
-	if (m == MAX_TIMEOUT) goto error;
-    switch ((twst = TW_STATUS)) {
+    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_TIMEOUT)); /* wait for transmission */
+	if (m > MAX_TIMEOUT) {
+		putch('6');
+		goto error;
+	}
+	switch ((twst = TW_STATUS)) {
         case TW_MR_SLA_ACK:
             break;
         case TW_MR_SLA_NACK:
@@ -166,9 +186,12 @@ begin:
     m = 0;
     twcr = _BV(TWINT) | _BV(TWEN); /* send NAK this time */
     TWCR = twcr;		/* clear int to start transmission */
-    while (((TWCR & _BV(TWINT)) == 0) && (++m < MAX_TIMEOUT)); /* wait for transmission */
-	if (m == MAX_TIMEOUT) goto error;
-    switch ((twst = TW_STATUS)) {
+    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_TIMEOUT)); /* wait for transmission */
+	if (m > MAX_TIMEOUT) {
+		putch('7');
+		goto error;
+	}
+	switch ((twst = TW_STATUS)) {
 	      case TW_MR_DATA_ACK:
 	      case TW_MR_DATA_NACK:
 	          buf = TWDR;
@@ -200,8 +223,11 @@ begin:
     /* Note [15] */
     m = 0;
     TWCR = _BV(TWINT) | _BV(TWSTA) | _BV(TWEN); /* send start condition */
-    while (((TWCR & _BV(TWINT)) == 0) && (++m < MAX_TIMEOUT)) ; /* wait for transmission */
-    if (m == MAX_TIMEOUT) return;
+    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_TIMEOUT)) ; /* wait for transmission */
+    if (m > MAX_TIMEOUT) {
+		putch('A');
+		return;
+	}
     switch ((twst = TW_STATUS)) {
 	      case TW_REP_START:		/* OK, but should not happen */
 	      case TW_START:
@@ -217,8 +243,11 @@ begin:
     m = 0;
     TWDR = I2C_EEPROM_ADDR;
     TWCR = _BV(TWINT) | _BV(TWEN); /* clear interrupt to start transmission */
-    while (((TWCR & _BV(TWINT)) == 0) && (++m < MAX_TIMEOUT)) ; /* wait for transmission */
-    if (m == MAX_TIMEOUT) goto error;
+    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_TIMEOUT)) ; /* wait for transmission */
+    if (m > MAX_TIMEOUT) {
+		putch('B');
+		goto error;
+	}
     switch ((twst = TW_STATUS)) {
 	      case TW_MT_SLA_ACK:
 	          break;
@@ -232,8 +261,11 @@ begin:
 
     TWDR = 0; m = 0;
     TWCR = _BV(TWINT) | _BV(TWEN); /* clear interrupt to start transmission */
-    while (((TWCR & _BV(TWINT)) == 0) && (++m < MAX_TIMEOUT)) ; /* wait for transmission */
-    if (m == MAX_TIMEOUT) goto error;
+    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_TIMEOUT)) ; /* wait for transmission */
+    if (m > MAX_TIMEOUT) {
+		putch('C');
+		goto error;
+	}
     switch ((twst = TW_STATUS)) {
 	      case TW_MT_DATA_ACK:
 	          break;
@@ -248,8 +280,11 @@ begin:
     m = 0;
     TWDR = 0;		/* low 8 bits of addr */
     TWCR = _BV(TWINT) | _BV(TWEN); /* clear interrupt to start transmission */
-    while (((TWCR & _BV(TWINT)) == 0) && (++m < MAX_TIMEOUT)); /* wait for transmission */
-    if (m == MAX_TIMEOUT) goto error;
+    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_TIMEOUT)); /* wait for transmission */
+    if (m > MAX_TIMEOUT) {
+		putch('D');
+		goto error;
+	}
     switch ((twst = TW_STATUS)) {
 	      case TW_MT_DATA_ACK:
 	          break;
@@ -265,8 +300,11 @@ begin:
     for (n=8; n ; n--) {
 	      TWDR = 0xFF; m = 0;
 	      TWCR = _BV(TWINT) | _BV(TWEN); /* start transmission */
-	      while (((TWCR & _BV(TWINT)) == 0)  && (++m < MAX_TIMEOUT)); /* wait for transmission */
-	      if (m == MAX_TIMEOUT) goto error;
+	      while (((TWCR & _BV(TWINT)) == 0)  && (m++ < MAX_TIMEOUT)); /* wait for transmission */
+	      if (m > MAX_TIMEOUT) {
+			putch('E');
+			goto error;
+		  }
 	      switch ((twst = TW_STATUS)) {
 		        case TW_MT_DATA_NACK:
 		            goto error;		/* device write protected -- Note [16] */

--- a/i2c.h
+++ b/i2c.h
@@ -60,7 +60,7 @@ begin:
 
     m=0;
     TWCR = _BV(TWINT) | _BV(TWSTA) | _BV(TWEN); /* send start condition */
-    while (((TWCR & _BV(TWINT)) == 0) & (m++ < MAX_ITER)) ; /* wait for transmission */
+    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_ITER)) ; /* wait for transmission */
     if (m == MAX_ITER) return 0xFF;
 	switch ((twst = TW_STATUS)) {
         case TW_REP_START:		// OK, but should not happen 
@@ -78,7 +78,7 @@ begin:
     m = 0;
     TWDR = I2C_EEPROM_ADDR | TW_WRITE;
     TWCR = _BV(TWINT) | _BV(TWEN); /* clear interrupt to start transmission */
-    while (((TWCR & _BV(TWINT)) == 0) & (m++ < MAX_ITER)) ; /* wait for transmission */
+    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_ITER)) ; /* wait for transmission */
     if (m == MAX_ITER) goto error;
 	switch ((twst = TW_STATUS)) {
         case TW_MT_SLA_ACK:
@@ -98,7 +98,7 @@ begin:
     m = 0;
     TWDR = ((uint16_t)eeaddr >> 8);		/* 16-bit word address device, send high 8 bits of addr */
     TWCR = _BV(TWINT) | _BV(TWEN); /* clear interrupt to start transmission */
-    while (((TWCR & _BV(TWINT)) == 0) & (m++ < MAX_ITER)); /* wait for transmission */
+    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_ITER)); /* wait for transmission */
 	if (m == MAX_ITER) goto error;
     switch ((twst = TW_STATUS)) {
         case TW_MT_DATA_ACK:
@@ -114,7 +114,7 @@ begin:
     m =0;
     TWDR = eeaddr;		/* low 8 bits of addr */
     TWCR = _BV(TWINT) | _BV(TWEN); /* clear interrupt to start transmission */
-    while (((TWCR & _BV(TWINT)) == 0) & (m++ < MAX_ITER)) ; /* wait for transmission */
+    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_ITER)) ; /* wait for transmission */
 	if (m == MAX_ITER) goto error;
     switch ((twst = TW_STATUS)) {
         case TW_MT_DATA_ACK:
@@ -133,7 +133,7 @@ begin:
     */
     m = 0;
     TWCR = _BV(TWINT) | _BV(TWSTA) | _BV(TWEN); /* send (rep.) start condition */
-    while (((TWCR & _BV(TWINT)) == 0) & (m++ < MAX_ITER)) ; /* wait for transmission */
+    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_ITER)) ; /* wait for transmission */
 	if (m == MAX_ITER) goto error;
     switch ((twst = TW_STATUS)) {
         case TW_START:		// OK, but should not happen 
@@ -149,7 +149,7 @@ begin:
     m = 0;
     TWDR = I2C_EEPROM_ADDR | TW_READ;
     TWCR = _BV(TWINT) | _BV(TWEN); /* clear interrupt to start transmission */
-    while (((TWCR & _BV(TWINT)) == 0) & (m++ < MAX_ITER)); /* wait for transmission */
+    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_ITER)); /* wait for transmission */
 	if (m == MAX_ITER) goto error;
     switch ((twst = TW_STATUS)) {
         case TW_MR_SLA_ACK:
@@ -165,7 +165,7 @@ begin:
     m = 0;
     twcr = _BV(TWINT) | _BV(TWEN); /* send NAK this time */
     TWCR = twcr;		/* clear int to start transmission */
-    while (((TWCR & _BV(TWINT)) == 0) & (m++ < MAX_ITER)); /* wait for transmission */
+    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_ITER)); /* wait for transmission */
 	if (m == MAX_ITER) goto error;
     switch ((twst = TW_STATUS)) {
 	      case TW_MR_DATA_ACK:
@@ -199,7 +199,7 @@ begin:
     /* Note [15] */
     m = 0;
     TWCR = _BV(TWINT) | _BV(TWSTA) | _BV(TWEN); /* send start condition */
-    while (((TWCR & _BV(TWINT)) == 0) & (m++ < MAX_ITER)) ; /* wait for transmission */
+    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_ITER)) ; /* wait for transmission */
     if (m == MAX_ITER) return;
     switch ((twst = TW_STATUS)) {
 	      case TW_REP_START:		/* OK, but should not happen */
@@ -216,7 +216,7 @@ begin:
     m = 0;
     TWDR = I2C_EEPROM_ADDR;
     TWCR = _BV(TWINT) | _BV(TWEN); /* clear interrupt to start transmission */
-    while (((TWCR & _BV(TWINT)) == 0) & (m++ < MAX_ITER)) ; /* wait for transmission */
+    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_ITER)) ; /* wait for transmission */
     if (m == MAX_ITER) goto error;
     switch ((twst = TW_STATUS)) {
 	      case TW_MT_SLA_ACK:
@@ -231,7 +231,7 @@ begin:
 
     TWDR = 0; m = 0;
     TWCR = _BV(TWINT) | _BV(TWEN); /* clear interrupt to start transmission */
-    while (((TWCR & _BV(TWINT)) == 0) & (m++ < MAX_ITER)) ; /* wait for transmission */
+    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_ITER)) ; /* wait for transmission */
     if (m == MAX_ITER) goto error;
     switch ((twst = TW_STATUS)) {
 	      case TW_MT_DATA_ACK:
@@ -247,7 +247,7 @@ begin:
     m = 0;
     TWDR = 0;		/* low 8 bits of addr */
     TWCR = _BV(TWINT) | _BV(TWEN); /* clear interrupt to start transmission */
-    while (((TWCR & _BV(TWINT)) == 0)  & (m++ < MAX_ITER)); /* wait for transmission */
+    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_ITER)); /* wait for transmission */
     if (m == MAX_ITER) goto error;
     switch ((twst = TW_STATUS)) {
 	      case TW_MT_DATA_ACK:
@@ -264,7 +264,7 @@ begin:
     for (n=8; n ; n--) {
 	      TWDR = 0xFF; m = 0;
 	      TWCR = _BV(TWINT) | _BV(TWEN); /* start transmission */
-	      while (((TWCR & _BV(TWINT)) == 0)  & (m++ < MAX_ITER)); /* wait for transmission */
+	      while (((TWCR & _BV(TWINT)) == 0)  && (m++ < MAX_ITER)); /* wait for transmission */
 	      if (m == MAX_ITER) goto error;
 	      switch ((twst = TW_STATUS)) {
 		        case TW_MT_DATA_NACK:

--- a/i2c.h
+++ b/i2c.h
@@ -17,6 +17,7 @@
  */
 
 #define MAX_ITER 200  //< maximum retries
+#define MAX_TIMEOUT 5000  //< maximum timeout while waiting for I2C response
 uint8_t twst;
 
 //uint8_t StartTwiTransfer(uint8_t dr)
@@ -60,8 +61,8 @@ begin:
 
     m=0;
     TWCR = _BV(TWINT) | _BV(TWSTA) | _BV(TWEN); /* send start condition */
-    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_ITER)) ; /* wait for transmission */
-    if (m == MAX_ITER) return 0xFF;
+    while (((TWCR & _BV(TWINT)) == 0) && (++m < MAX_TIMEOUT)) ; /* wait for transmission */
+    if (m == MAX_TIMEOUT) return 0xFF;
 	switch ((twst = TW_STATUS)) {
         case TW_REP_START:		// OK, but should not happen 
         case TW_START:
@@ -78,8 +79,8 @@ begin:
     m = 0;
     TWDR = I2C_EEPROM_ADDR | TW_WRITE;
     TWCR = _BV(TWINT) | _BV(TWEN); /* clear interrupt to start transmission */
-    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_ITER)) ; /* wait for transmission */
-    if (m == MAX_ITER) goto error;
+    while (((TWCR & _BV(TWINT)) == 0) && (++m < MAX_TIMEOUT)) ; /* wait for transmission */
+    if (m == MAX_TIMEOUT) goto error;
 	switch ((twst = TW_STATUS)) {
         case TW_MT_SLA_ACK:
             break;
@@ -98,8 +99,8 @@ begin:
     m = 0;
     TWDR = ((uint16_t)eeaddr >> 8);		/* 16-bit word address device, send high 8 bits of addr */
     TWCR = _BV(TWINT) | _BV(TWEN); /* clear interrupt to start transmission */
-    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_ITER)); /* wait for transmission */
-	if (m == MAX_ITER) goto error;
+    while (((TWCR & _BV(TWINT)) == 0) && (++m < MAX_TIMEOUT)); /* wait for transmission */
+	if (m == MAX_TIMEOUT) goto error;
     switch ((twst = TW_STATUS)) {
         case TW_MT_DATA_ACK:
             break;
@@ -111,11 +112,11 @@ begin:
             goto error;		/* must send stop condition */
     }
 
-    m =0;
+    m = 0;
     TWDR = eeaddr;		/* low 8 bits of addr */
     TWCR = _BV(TWINT) | _BV(TWEN); /* clear interrupt to start transmission */
-    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_ITER)) ; /* wait for transmission */
-	if (m == MAX_ITER) goto error;
+    while (((TWCR & _BV(TWINT)) == 0) && (++m < MAX_TIMEOUT)) ; /* wait for transmission */
+	if (m == MAX_TIMEOUT) goto error;
     switch ((twst = TW_STATUS)) {
         case TW_MT_DATA_ACK:
             break;
@@ -133,8 +134,8 @@ begin:
     */
     m = 0;
     TWCR = _BV(TWINT) | _BV(TWSTA) | _BV(TWEN); /* send (rep.) start condition */
-    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_ITER)) ; /* wait for transmission */
-	if (m == MAX_ITER) goto error;
+    while (((TWCR & _BV(TWINT)) == 0) && (++m < MAX_TIMEOUT)) ; /* wait for transmission */
+	if (m == MAX_TIMEOUT) goto error;
     switch ((twst = TW_STATUS)) {
         case TW_START:		// OK, but should not happen 
         case TW_REP_START:
@@ -149,8 +150,8 @@ begin:
     m = 0;
     TWDR = I2C_EEPROM_ADDR | TW_READ;
     TWCR = _BV(TWINT) | _BV(TWEN); /* clear interrupt to start transmission */
-    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_ITER)); /* wait for transmission */
-	if (m == MAX_ITER) goto error;
+    while (((TWCR & _BV(TWINT)) == 0) && (++m < MAX_TIMEOUT)); /* wait for transmission */
+	if (m == MAX_TIMEOUT) goto error;
     switch ((twst = TW_STATUS)) {
         case TW_MR_SLA_ACK:
             break;
@@ -165,8 +166,8 @@ begin:
     m = 0;
     twcr = _BV(TWINT) | _BV(TWEN); /* send NAK this time */
     TWCR = twcr;		/* clear int to start transmission */
-    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_ITER)); /* wait for transmission */
-	if (m == MAX_ITER) goto error;
+    while (((TWCR & _BV(TWINT)) == 0) && (++m < MAX_TIMEOUT)); /* wait for transmission */
+	if (m == MAX_TIMEOUT) goto error;
     switch ((twst = TW_STATUS)) {
 	      case TW_MR_DATA_ACK:
 	      case TW_MR_DATA_NACK:
@@ -199,8 +200,8 @@ begin:
     /* Note [15] */
     m = 0;
     TWCR = _BV(TWINT) | _BV(TWSTA) | _BV(TWEN); /* send start condition */
-    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_ITER)) ; /* wait for transmission */
-    if (m == MAX_ITER) return;
+    while (((TWCR & _BV(TWINT)) == 0) && (++m < MAX_TIMEOUT)) ; /* wait for transmission */
+    if (m == MAX_TIMEOUT) return;
     switch ((twst = TW_STATUS)) {
 	      case TW_REP_START:		/* OK, but should not happen */
 	      case TW_START:
@@ -216,8 +217,8 @@ begin:
     m = 0;
     TWDR = I2C_EEPROM_ADDR;
     TWCR = _BV(TWINT) | _BV(TWEN); /* clear interrupt to start transmission */
-    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_ITER)) ; /* wait for transmission */
-    if (m == MAX_ITER) goto error;
+    while (((TWCR & _BV(TWINT)) == 0) && (++m < MAX_TIMEOUT)) ; /* wait for transmission */
+    if (m == MAX_TIMEOUT) goto error;
     switch ((twst = TW_STATUS)) {
 	      case TW_MT_SLA_ACK:
 	          break;
@@ -231,8 +232,8 @@ begin:
 
     TWDR = 0; m = 0;
     TWCR = _BV(TWINT) | _BV(TWEN); /* clear interrupt to start transmission */
-    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_ITER)) ; /* wait for transmission */
-    if (m == MAX_ITER) goto error;
+    while (((TWCR & _BV(TWINT)) == 0) && (++m < MAX_TIMEOUT)) ; /* wait for transmission */
+    if (m == MAX_TIMEOUT) goto error;
     switch ((twst = TW_STATUS)) {
 	      case TW_MT_DATA_ACK:
 	          break;
@@ -247,8 +248,8 @@ begin:
     m = 0;
     TWDR = 0;		/* low 8 bits of addr */
     TWCR = _BV(TWINT) | _BV(TWEN); /* clear interrupt to start transmission */
-    while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_ITER)); /* wait for transmission */
-    if (m == MAX_ITER) goto error;
+    while (((TWCR & _BV(TWINT)) == 0) && (++m < MAX_TIMEOUT)); /* wait for transmission */
+    if (m == MAX_TIMEOUT) goto error;
     switch ((twst = TW_STATUS)) {
 	      case TW_MT_DATA_ACK:
 	          break;
@@ -264,8 +265,8 @@ begin:
     for (n=8; n ; n--) {
 	      TWDR = 0xFF; m = 0;
 	      TWCR = _BV(TWINT) | _BV(TWEN); /* start transmission */
-	      while (((TWCR & _BV(TWINT)) == 0)  && (m++ < MAX_ITER)); /* wait for transmission */
-	      if (m == MAX_ITER) goto error;
+	      while (((TWCR & _BV(TWINT)) == 0)  && (++m < MAX_TIMEOUT)); /* wait for transmission */
+	      if (m == MAX_TIMEOUT) goto error;
 	      switch ((twst = TW_STATUS)) {
 		        case TW_MT_DATA_NACK:
 		            goto error;		/* device write protected -- Note [16] */

--- a/i2c.h
+++ b/i2c.h
@@ -63,10 +63,11 @@ begin:
     TWCR = _BV(TWINT) | _BV(TWSTA) | _BV(TWEN); /* send start condition */
     while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_TIMEOUT)) ; /* wait for transmission */
 	if (m > MAX_TIMEOUT) {
+#ifdef DEBUG_ON
 		putch('1');
+#endif
 		return 0xFF; 
 	}
-	
 	switch ((twst = TW_STATUS)) {
         case TW_REP_START:		// OK, but should not happen 
         case TW_START:
@@ -85,10 +86,11 @@ begin:
     TWCR = _BV(TWINT) | _BV(TWEN); /* clear interrupt to start transmission */
     while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_TIMEOUT)) ; /* wait for transmission */
     if (m > MAX_TIMEOUT) {
+#ifdef DEBUG_ON
 		putch('2');
+#endif
 		goto error;
 	}
-	
 	switch ((twst = TW_STATUS)) {
         case TW_MT_SLA_ACK:
             break;
@@ -109,7 +111,9 @@ begin:
     TWCR = _BV(TWINT) | _BV(TWEN); /* clear interrupt to start transmission */
     while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_TIMEOUT)); /* wait for transmission */
 	if (m > MAX_TIMEOUT) {
+#ifdef DEBUG_ON
 		putch('3');
+#endif
 		goto error;
 	}
 	switch ((twst = TW_STATUS)) {
@@ -128,7 +132,9 @@ begin:
     TWCR = _BV(TWINT) | _BV(TWEN); /* clear interrupt to start transmission */
     while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_TIMEOUT)) ; /* wait for transmission */
 	if (m > MAX_TIMEOUT){
+#ifdef DEBUG_ON
 		putch('4');
+#endif
 		goto error;
 	}
 	switch ((twst = TW_STATUS)) {
@@ -150,7 +156,9 @@ begin:
     TWCR = _BV(TWINT) | _BV(TWSTA) | _BV(TWEN); /* send (rep.) start condition */
     while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_TIMEOUT)) ; /* wait for transmission */
 	if (m > MAX_TIMEOUT) {
+#ifdef DEBUG_ON
 		putch('5');
+#endif
 		goto error;
 	}
 	switch ((twst = TW_STATUS)) {
@@ -169,7 +177,9 @@ begin:
     TWCR = _BV(TWINT) | _BV(TWEN); /* clear interrupt to start transmission */
     while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_TIMEOUT)); /* wait for transmission */
 	if (m > MAX_TIMEOUT) {
+#ifdef DEBUG_ON
 		putch('6');
+#endif
 		goto error;
 	}
 	switch ((twst = TW_STATUS)) {
@@ -188,7 +198,9 @@ begin:
     TWCR = twcr;		/* clear int to start transmission */
     while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_TIMEOUT)); /* wait for transmission */
 	if (m > MAX_TIMEOUT) {
+#ifdef DEBUG_ON
 		putch('7');
+#endif
 		goto error;
 	}
 	switch ((twst = TW_STATUS)) {
@@ -225,7 +237,9 @@ begin:
     TWCR = _BV(TWINT) | _BV(TWSTA) | _BV(TWEN); /* send start condition */
     while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_TIMEOUT)) ; /* wait for transmission */
     if (m > MAX_TIMEOUT) {
+#ifdef DEBUG_ON
 		putch('A');
+#endif
 		return;
 	}
     switch ((twst = TW_STATUS)) {
@@ -245,7 +259,9 @@ begin:
     TWCR = _BV(TWINT) | _BV(TWEN); /* clear interrupt to start transmission */
     while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_TIMEOUT)) ; /* wait for transmission */
     if (m > MAX_TIMEOUT) {
+#ifdef DEBUG_ON
 		putch('B');
+#endif
 		goto error;
 	}
     switch ((twst = TW_STATUS)) {
@@ -263,7 +279,9 @@ begin:
     TWCR = _BV(TWINT) | _BV(TWEN); /* clear interrupt to start transmission */
     while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_TIMEOUT)) ; /* wait for transmission */
     if (m > MAX_TIMEOUT) {
+#ifdef DEBUG_ON
 		putch('C');
+#endif
 		goto error;
 	}
     switch ((twst = TW_STATUS)) {
@@ -282,7 +300,9 @@ begin:
     TWCR = _BV(TWINT) | _BV(TWEN); /* clear interrupt to start transmission */
     while (((TWCR & _BV(TWINT)) == 0) && (m++ < MAX_TIMEOUT)); /* wait for transmission */
     if (m > MAX_TIMEOUT) {
+#ifdef DEBUG_ON
 		putch('D');
+#endif
 		goto error;
 	}
     switch ((twst = TW_STATUS)) {
@@ -302,7 +322,9 @@ begin:
 	      TWCR = _BV(TWINT) | _BV(TWEN); /* start transmission */
 	      while (((TWCR & _BV(TWINT)) == 0)  && (m++ < MAX_TIMEOUT)); /* wait for transmission */
 	      if (m > MAX_TIMEOUT) {
+#ifdef DEBUG_ON
 			putch('E');
+#endif
 			goto error;
 		  }
 	      switch ((twst = TW_STATUS)) {


### PR DESCRIPTION
Hi, I added timeouts to wait for transmission loops to avoid the sketch getting stuck if the memory chip is not found of the bus fails for some reason, i.e. no pullups, broken wire, etc.

I used the existing MAX_ITER constant but hits might be changed depending on how long we need to wait.

As the timeout action I copied the action on the default: case of the corresponding switch statement. Please review if this is correct since I'm not a great specialist on how the I2C bus works.

I hope this works!